### PR TITLE
Ejection

### DIFF
--- a/spock/feature_functions.py
+++ b/spock/feature_functions.py
@@ -113,7 +113,7 @@ def get_tseries(sim, args):
     for i, time in enumerate(times):
         try:
             sim.integrate(time, exact_finish_time=0)
-        except rebound.Collision:
+        except (rebound.Collision, rebound.Escape):
             stable = False
             return triotseries, stable
 

--- a/spock/nbodyregressor.py
+++ b/spock/nbodyregressor.py
@@ -35,7 +35,7 @@ class NbodyRegressor():
 
         try:
             sim.integrate(tmax, exact_finish_time=0)
-        except rebound.Collision:
+        except (rebound.Collision, rebound.Escape):
             if archive_filename:
                 sim.simulationarchive_snapshot(archive_filename)
             return sim.t

--- a/spock/simsetup.py
+++ b/spock/simsetup.py
@@ -41,7 +41,10 @@ def init_sim_parameters(sim):
         sim.collision = 'line'  # use line if using newer version of REBOUND
     except:
         sim.collision = 'direct'# fall back for older versions
-    
+
+    maxd = np.array([p.d for p in sim.particles[1:sim.N_real]]).max()
+    sim.exit_max_distance = 100*maxd
+                
     sim.ri_whfast.keep_unsynchronized = 0
     sim.ri_whfast.safe_mode = 1
 

--- a/spock/test/test_classifier.py
+++ b/spock/test/test_classifier.py
@@ -136,6 +136,14 @@ class TestClassifier(unittest.TestCase):
         sim.add(m=1.e-5, a=3.)
         self.assertEqual(self.model.predict_stable(sim), 0)
     
+    def test_escape(self):
+        sim = rebound.Simulation()
+        sim.add(m=1.)
+        sim.add(m=1.e-12, P=3.14, e=0.03, l=0.5)
+        sim.add(m=1.e-12, P=4.396, e=0.03, l=4.8)
+        sim.add(m=1.e-12, a=100, e=0.999)
+        self.assertEqual(self.model.predict_stable(sim), 0)
+    
     def test_unstable_in_short_integration(self):
         sim = unstablesim()
         self.assertEqual(self.model.predict_stable(sim), 0)

--- a/spock/test/test_nbody.py
+++ b/spock/test/test_nbody.py
@@ -82,6 +82,14 @@ class TestNbody(unittest.TestCase):
         sim.add(m=1.e-5, a=3.)
         self.assertEqual(self.model.predict_stable(sim, tmax=1e4), 0)
     
+    def test_escape(self):
+        sim = rebound.Simulation()
+        sim.add(m=1.)
+        sim.add(m=1.e-12, P=3.14, e=0.03, l=0.5)
+        sim.add(m=1.e-12, P=4.396, e=0.03, l=4.8)
+        sim.add(m=1.e-12, a=100, e=0.999)
+        self.assertEqual(self.model.predict_stable(sim, tmax=1e4), 0)
+    
     def test_unstable_in_short_integration(self):
         sim = unstablesim()
         self.assertEqual(self.model.predict_stable(sim, tmax=1e4), 0)


### PR DESCRIPTION
Check for ejections in addition to collisions in both the classifier and nbody regressor.

These outcomes are rare in our close-in, low-mass systems, but can happen when running wide grids of simulations including highly eccentric, orbit-crossing configurations.