### PR TITLE
Fix `inf` import for PyTorch 2.0

### DIFF
--- a/spock/spock_reg_model.py
+++ b/spock/spock_reg_model.py
@@ -16,7 +16,10 @@ import math
 import pytorch_lightning as pl
 from pytorch_lightning import Trainer
 import math
-from torch._six import inf
+try:
+    from torch._six import inf
+except ModuleNotFoundError:
+    from torch import inf
 from functools import wraps
 import warnings
 from torch.optim.optimizer import Optimizer


### PR DESCRIPTION
This should fix #21

@dtamayo want to review?

@aobertas does this fix it for you?