### PR TITLE
Add github action testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
           - macos-latest
         python-version:
           - '3.12'
-          - '3.8'
+          - '3.9'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        python-version:
+          - '3.12'
+          - '3.8'
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: "Install spock"
+        run: |
+            python -m pip install --upgrade pip
+            pip install .[test]
+      - name: "Run tests"
+        run: python -m unittest discover
+        continue-on-error: true
+        # TODO: fix tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "spock"
 version = "1.6.0"
 description = "Stability of Planetary Orbital Configurations Klassifier"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"  # Limited by pytensor (<= celmech)
 license = {file = "LICENSE"}
 authors = [
     {name = "Daniel Tamayo", email = "tamayo.daniel@gmail.com"},


### PR DESCRIPTION
Right now this is just for debugging – it allows for failures – but we could turn that off in the future.

- Tests macOS and Linux on 3.8 and 3.12 Python.
- Also adds dependabot for version updates


Note this depends on #25 so that should be reviewed first.