### PR TITLE
Automatically remove unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  # Unused imports
+  - repo: https://github.com/hadialqattan/pycln
+    rev: "v2.4.0"
+    hooks:
+      - id: pycln
+  # Sorted imports
+  - repo: https://github.com/PyCQA/isort
+    rev: "5.13.2"
+    hooks:
+      - id: isort
+        additional_dependencies: [toml]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python 
+language: python
 sudo: false
 
 env:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ print(feature_model.predict_stable(sim))
 # >>> 0.06591137
 ```
 
-That model provides a simple scalar probability of stability over a billion orbits. 
+That model provides a simple scalar probability of stability over a billion orbits.
 We can instead estimate its median expected instability time using the deep regressor from [Cranmer et al., 2021](https://arxiv.org/abs/2101.04117).
 
 ```python

--- a/docs/start.md
+++ b/docs/start.md
@@ -3,7 +3,7 @@
 
 ## Installation
 
-SPOCK is compatible with both Linux and Mac. 
+SPOCK is compatible with both Linux and Mac.
 
 Install with:
 

--- a/generate_training_data/clean.py
+++ b/generate_training_data/clean.py
@@ -1,6 +1,5 @@
-from subprocess import call
 from collections import OrderedDict
-import sys
+from subprocess import call
 
 datapath = '../training_data/'
 

--- a/generate_training_data/generate_data.py
+++ b/generate_training_data/generate_data.py
@@ -1,15 +1,19 @@
-import rebound
-import numpy as np
-from subprocess import call
 import os
 import sys
 import warnings
+from subprocess import call
+
+import numpy as np
+import rebound
+
 warnings.filterwarnings('ignore') # to suppress warnings about REBOUND versions that I've already tested
 from collections import OrderedDict
+
 from training_data_functions import gen_training_data
+
 sys.path.append(os.path.join(sys.path[0], '..'))
-from feature_functions import features
 from additional_feature_functions import additional_features
+from feature_functions import features
 
 runfunc = features
 datapath = '../data/'

--- a/generate_training_data/generate_metadata.py
+++ b/generate_training_data/generate_metadata.py
@@ -1,9 +1,11 @@
-import rebound
+import os
+import warnings
+from subprocess import call
+
 import numpy as np
 import pandas as pd
-import os
-from subprocess import call
-import warnings
+import rebound
+
 warnings.filterwarnings('ignore') # filter REBOUND warnings about version that I've already tested
 
 datapath = '../data/'

--- a/generate_training_data/training_data_functions.py
+++ b/generate_training_data/training_data_functions.py
@@ -1,11 +1,14 @@
-import rebound
+import sys
+
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import dask.dataframe as dd
-import sys
+import rebound
+
 sys.path.append('../spock')
 sys.path.append('../../spock')
 from simsetup import init_sim_parameters
+
 
 def training_data(row, safolder, runfunc, args):
     try:

--- a/jupyter_examples/ipynb2py.py
+++ b/jupyter_examples/ipynb2py.py
@@ -1,5 +1,6 @@
 import json
 import sys
+
 exec("import matplotlib as mpl")
 exec("mpl.use(\"Agg\")")
 
@@ -17,6 +18,7 @@ for c in ipynb["cells"]:
             if s[0] != "%":
                 code += s.rstrip('\n')+"\n"
 import socket
+
 try:
     exec(code)
 except socket.error: 

--- a/paper_plots/generatePratios.py
+++ b/paper_plots/generatePratios.py
@@ -1,8 +1,9 @@
-import rebound
 import pandas as pd
+import rebound
+
 if rebound.__githash__ != '6fb912f615ca542b670ab591375191d1ed914672':
     print('Check out rebound commit 6fb912f615ca542b670ab591375191d1ed914672 and rerun script. See spock/training.md')
-    [
+
 datapath = '../data/'
 
 randompath = 'random/simulation_archives/runs/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev-dependencies = [
     "ipykernel>=6.29.4",
     "matplotlib>=3.9.0",
     "pre-commit>=3.7.1",
+    "pandas>=2.2.2",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "rebound>=3.14.0",           # classifier regressor analytical
     "scikit-learn",              # classifier regressor
-    "xgboost>=1.1.0",            # classifier 
+    "xgboost>=1.1.0",            # classifier
     "torch>=1.5.1",              #            regressor
     "safetensors>=0.4.0,<0.5.0", #            regressor
     "scipy",                     #            regressor
@@ -48,13 +48,17 @@ test = [
 [project.urls]
 Homepage = "https://github.com/dtamayo/spock"
 
-[tool]
-rye = { dev-dependencies = [
+[tool.rye]
+dev-dependencies = [
     "ipython>=8.24.0",
     "jupyter>=1.0.0",
     "ipykernel>=6.29.4",
     "matplotlib>=3.9.0",
-] }
+    "pre-commit>=3.7.1",
+]
+
+[tool.isort]
+profile = "black"
 
 [tool.setuptools_scm]
 version_scheme = "release-branch-semver"

--- a/run_integrations/runcomparison.py
+++ b/run_integrations/runcomparison.py
@@ -1,10 +1,11 @@
-import rebound
-from multiprocessing import Pool
-from itertools import repeat
-from runfunctions import run_random
-import pandas as pd
-import sys
 import math
+import sys
+from itertools import repeat
+from multiprocessing import Pool
+
+import pandas as pd
+import rebound
+from runfunctions import run_random
 
 N_systems=2000
 tmax = 1.e6

--- a/run_integrations/runfunctions.py
+++ b/run_integrations/runfunctions.py
@@ -1,14 +1,15 @@
 # Run script with python run.py sim_id, where sim_id is an integer to use for the sim_id (and the RNG seed). Runs a base system and a shadow system
-import numpy as np
-import rebound
-from random import random, uniform, seed
-import time
-import sys
 import math
 import random
-from celmech import Andoyer, Poincare, AndoyerHamiltonian
+import time
+from random import random, seed, uniform
+
+import numpy as np
+import rebound
+from celmech import Andoyer, AndoyerHamiltonian, Poincare
 from celmech.andoyer import get_Xstarres
 from scipy.integrate import ode
+
 
 def logunif(r, mini, maxi):
     logmin = np.log10(mini)

--- a/run_integrations/runrandom.py
+++ b/run_integrations/runrandom.py
@@ -1,5 +1,6 @@
-from runfunctions import run_random
 import sys
+
+from runfunctions import run_random
 
 sim_id = int(sys.argv[1])
 runstring = sys.argv[2]

--- a/run_integrations/runrandomscript.py
+++ b/run_integrations/runrandomscript.py
@@ -1,7 +1,7 @@
-import numpy as np
 import sys
 from subprocess import call
-import time
+
+import numpy as np
 import pandas as pd
 
 Nruns = int(sys.argv[1])

--- a/run_integrations/runresonant.py
+++ b/run_integrations/runresonant.py
@@ -1,5 +1,6 @@
-from runfunctions import run_resonant
 import sys
+
+from runfunctions import run_resonant
 
 seed = int(sys.argv[1])
 runstring = sys.argv[2]

--- a/run_integrations/runresonantscript.py
+++ b/run_integrations/runresonantscript.py
@@ -1,7 +1,7 @@
-import numpy as np
 import sys
 from subprocess import call
-import time
+
+import numpy as np
 import pandas as pd
 
 Nruns = int(sys.argv[1])

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import setup
 
 kwargs = dict(

--- a/spock/AMD_functions.py
+++ b/spock/AMD_functions.py
@@ -1,6 +1,7 @@
-import rebound
 import numpy as np
+import rebound
 from scipy.optimize import brenth
+
 
 def F(e,alpha,gamma):
     """Equation 35 of Laskar & Petit (2017)"""

--- a/spock/__init__.py
+++ b/spock/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Stability of Planetary Orbital Configurations Klassifier"""
 
-from .featureclassifier import FeatureClassifier
-from .deepregressor import DeepRegressor
-from .nbodyregressor import NbodyRegressor
 from .analyticalclassifier import AnalyticalClassifier
+from .deepregressor import DeepRegressor
+from .featureclassifier import FeatureClassifier
+from .nbodyregressor import NbodyRegressor
 from .version import __version__
 
 __all__ = ["FeatureClassifier", "DeepRegressor", "NbodyRegressor", "AnalyticalClassifier"]

--- a/spock/additional_feature_functions.py
+++ b/spock/additional_feature_functions.py
@@ -1,8 +1,9 @@
 from collections import OrderedDict
 
 import numpy as np
-from AMD_functions import AMD, AMD_crit
-from feature_functions import find_strongest_MMR, get_pairs, populate_trio
+
+from .AMD_functions import AMD, AMD_crit
+from .feature_functions import find_strongest_MMR, get_pairs, populate_trio
 
 
 def additional_get_tseries(sim, args):

--- a/spock/additional_feature_functions.py
+++ b/spock/additional_feature_functions.py
@@ -1,7 +1,9 @@
-import numpy as np
 from collections import OrderedDict
-from feature_functions import get_pairs, find_strongest_MMR, populate_trio
+
+import numpy as np
 from AMD_functions import AMD, AMD_crit
+from feature_functions import find_strongest_MMR, get_pairs, populate_trio
+
 
 def additional_get_tseries(sim, args):
     Norbits = args[0]

--- a/spock/analyticalclassifier.py
+++ b/spock/analyticalclassifier.py
@@ -1,11 +1,14 @@
-import rebound
-import numpy as np
-from celmech.secular import LaplaceLagrangeSystem
-from celmech import Poincare
+from itertools import combinations
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
-from itertools import combinations
+
+import numpy as np
+import rebound
+from celmech import Poincare
+from celmech.secular import LaplaceLagrangeSystem
+
 from .simsetup import init_sim_parameters
+
 
 def eminus_max(lsys, Lambda, i1, i2):
     if i1 > i2:

--- a/spock/deepregressor.py
+++ b/spock/deepregressor.py
@@ -1,20 +1,22 @@
-import numpy as np
+import glob
 import math
 import os
-from collections import OrderedDict
-from .tseries_feature_functions import get_extended_tseries
-import torch
-import glob
-from .spock_reg_model import load_swag_safetensors
-import torch
+import random
 import warnings
-import einops as E
-from scipy.integrate import quad
-from scipy.interpolate import interp1d
-from .simsetup import init_sim_parameters
+from collections import OrderedDict
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool as Pool
-import random
+
+import einops as E
+import numpy as np
+import torch
+from scipy.integrate import quad
+from scipy.interpolate import interp1d
+
+from .simsetup import init_sim_parameters
+from .spock_reg_model import load_swag_safetensors
+from .tseries_feature_functions import get_extended_tseries
+
 warnings.filterwarnings('ignore', "DeprecationWarning: Using or importing the ABCs")
 
 def fitted_prior():

--- a/spock/feature_functions.py
+++ b/spock/feature_functions.py
@@ -1,6 +1,8 @@
-import rebound
-import numpy as np
 from collections import OrderedDict
+
+import numpy as np
+import rebound
+
 
 ######################### Taken from celmech github.com/shadden/celmech
 def farey_sequence(n):

--- a/spock/featureclassifier.py
+++ b/spock/featureclassifier.py
@@ -1,11 +1,14 @@
-import numpy as np
 import os
-import rebound
-from xgboost import XGBClassifier
-from .feature_functions import features
-from .simsetup import init_sim_parameters
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
+
+import numpy as np
+import rebound
+from xgboost import XGBClassifier
+
+from .feature_functions import features
+from .simsetup import init_sim_parameters
+
 
 class FeatureClassifier():
     def __init__(self, modelfile='featureclassifier.json'):

--- a/spock/modelfitting.py
+++ b/spock/modelfitting.py
@@ -1,7 +1,7 @@
-from sklearn.metrics import precision_recall_curve
-from sklearn.metrics import roc_curve, confusion_matrix, auc
-from sklearn import metrics
 import numpy as np
+from sklearn import metrics
+from sklearn.metrics import auc, confusion_matrix, precision_recall_curve, roc_curve
+
 
 def hasnull(row):
     numnulls = row.isnull().sum()

--- a/spock/nbodyregressor.py
+++ b/spock/nbodyregressor.py
@@ -1,8 +1,11 @@
+from multiprocessing import cpu_count
+from multiprocessing.pool import ThreadPool
+
 import numpy as np
 import rebound
+
 from .simsetup import init_sim_parameters
-from multiprocessing.pool import ThreadPool
-from multiprocessing import cpu_count
+
 
 class NbodyRegressor():
     def __init__(self):

--- a/spock/simsetup.py
+++ b/spock/simsetup.py
@@ -1,6 +1,7 @@
 import numpy as np
 import rebound
 
+
 def check_hyperbolic(sim):
     orbits = sim.orbits()
     amin = np.min([o.a for o in orbits])

--- a/spock/spock_reg_model.py
+++ b/spock/spock_reg_model.py
@@ -1,6 +1,8 @@
 import json
 import math
 import pickle as pkl
+import warnings
+from collections import OrderedDict
 from copy import deepcopy as copy
 
 import numpy as np
@@ -10,16 +12,12 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import PowerTransformer, StandardScaler
 from torch import nn
 from torch.autograd import Variable
+from torch.optim.optimizer import Optimizer
 
 try:
     from torch._six import inf
 except ModuleNotFoundError:
     from torch import inf
-
-import warnings
-from collections import OrderedDict
-
-from torch.optim.optimizer import Optimizer
 
 
 class CustomOneCycleLR(torch.optim.lr_scheduler._LRScheduler):

--- a/spock/spock_reg_model.py
+++ b/spock/spock_reg_model.py
@@ -1,21 +1,25 @@
-import pickle as pkl
-from copy import deepcopy as copy
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import StandardScaler, PowerTransformer
-import numpy as np
-import torch
-from torch import nn
-from torch.autograd import Variable
-from safetensors.torch import load_file as load_safetensors
 import json
 import math
+import pickle as pkl
+from copy import deepcopy as copy
+
+import numpy as np
+import torch
+from safetensors.torch import load_file as load_safetensors
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import PowerTransformer, StandardScaler
+from torch import nn
+from torch.autograd import Variable
+
 try:
     from torch._six import inf
 except ModuleNotFoundError:
     from torch import inf
+
 import warnings
-from torch.optim.optimizer import Optimizer
 from collections import OrderedDict
+
+from torch.optim.optimizer import Optimizer
 
 
 class CustomOneCycleLR(torch.optim.lr_scheduler._LRScheduler):

--- a/spock/test/test_analytical.py
+++ b/spock/test/test_analytical.py
@@ -1,8 +1,11 @@
-import rebound
 import unittest
+
+import rebound
+
 from spock import AnalyticalClassifier, NbodyRegressor
 from spock.feature_functions import get_tseries
 from spock.simsetup import init_sim_parameters
+
 
 def unstablesimecc():
     sim = rebound.Simulation()

--- a/spock/test/test_classifier.py
+++ b/spock/test/test_classifier.py
@@ -1,8 +1,11 @@
-import rebound
 import unittest
+
+import rebound
+
 from spock import FeatureClassifier, NbodyRegressor
 from spock.feature_functions import get_tseries
 from spock.simsetup import init_sim_parameters
+
 
 def unstablesim():
     sim = rebound.Simulation()

--- a/spock/test/test_nbody.py
+++ b/spock/test/test_nbody.py
@@ -1,9 +1,12 @@
-import numpy as np
 import unittest
+
+import numpy as np
 import rebound
+
 from spock import NbodyRegressor
-from spock.simsetup import init_sim_parameters
 from spock.feature_functions import features
+from spock.simsetup import init_sim_parameters
+
 
 def unstablesim():
     sim = rebound.Simulation()

--- a/spock/test/test_regression.py
+++ b/spock/test/test_regression.py
@@ -1,7 +1,9 @@
-import rebound
 import unittest
-from spock import NbodyRegressor, DeepRegressor
+
 import numpy as np
+import rebound
+
+from spock import DeepRegressor, NbodyRegressor
 
 SAMPLE_SETTINGS = dict(samples=1000, max_model_samples=30)
 

--- a/spock/test/test_simsetup.py
+++ b/spock/test/test_simsetup.py
@@ -1,8 +1,11 @@
-import rebound
 import unittest
+
 import numpy as np
+import rebound
+
 from spock import FeatureClassifier
 from spock.simsetup import init_sim_parameters
+
 
 def unstablesim():
     sim = rebound.Simulation()

--- a/spock/tseries_feature_functions.py
+++ b/spock/tseries_feature_functions.py
@@ -1,7 +1,9 @@
-import rebound
-import numpy as np
-from scipy.optimize import brenth
 from collections import OrderedDict
+
+import numpy as np
+import rebound
+from scipy.optimize import brenth
+
 from .feature_functions import find_strongest_MMR
 
 # sorts out which pair of planets has a smaller EMcross, labels that pair inner, other adjacent pair outer

--- a/train_models/translate_to_safetensors.py
+++ b/train_models/translate_to_safetensors.py
@@ -1,8 +1,10 @@
 import argparse
-import torch
-import pytorch_lightning
 import json
+
+import pytorch_lightning  # pycl: ignore
+import torch
 from safetensors.torch import save_file
+
 
 def main():
     parser = argparse.ArgumentParser(description="Translate saved model to safetensors")


### PR DESCRIPTION
Depends on #27 

- Automatically remove unused imports to help avoid fixes on #27
- Also added automatic sorting of imports into [standard library, third-party, internal] – and alphabetical within the groups
- Add pre-commit support (can either use locally with `pre-commit run --all-files` or with https://pre-commit.ci/ to add it to the CI)
