### PR TITLE
Fixed error with hyperbolic trajectories and with testing function.

### DIFF
--- a/spock/featureclassifier.py
+++ b/spock/featureclassifier.py
@@ -152,7 +152,7 @@ class FeatureClassifier:
         if Norbits > Nbodytmax:
             Norbits = Nbodytmax # failsafe to avoid cases with very long short integration times
             warnings.warn(f'Min secular timescale > Nbodytmax orbits of inner most planet '\
-                          f'Defaulting to integrating to {Nbodytmax} orbits. Might affect model performance')
+                          f'Defaulting to integrating to {Nbodytmax} orbits. Might affect model performance.')
         # set the number of outputs in short integration to be same as in original model (80 outputs over 1e4 orbits)
         Nout = int((Norbits / 1e4) * 80)
 

--- a/spock/features.py
+++ b/spock/features.py
@@ -437,8 +437,10 @@ def getIntPrat( Pratio: list):
     maxperiodratio = Pratio+delta # too many resonances close to 1
     if maxperiodratio >.999:
         maxperiodratio =.999
+    if minperiodratio < 0:
+        minperiodratio = 0 # account for escaped orbits
     res = resonant_period_ratios(minperiodratio,maxperiodratio, order=maxorder)
-    ratio = [10000000,10]
+    ratio = [10,10000000] # inner planet must have smaller period
     for i,each in enumerate(res):
         if np.abs((each[0]/each[1])-Pratio)<np.abs((ratio[0]/ratio[1])-Pratio):
             #which = i

--- a/spock/test/test_classifier.py
+++ b/spock/test/test_classifier.py
@@ -188,6 +188,7 @@ class TestClassifier(unittest.TestCase):
         sim = setup_sim(sim)
         testClass = FeatureClassifier()
         trios = [Trio(trio_indices=[1,2,3], sim=sim, Nout=80)]
+        trios[0].fill_starting_features(sim)
         _, _ = testClass.get_tseries(sim, trios, Norbits=1e4, Nout=80)
         x1 = sim.particles[1].x
 


### PR DESCRIPTION
Added additional checks for hyperbolic trajectories when calculating period ratios and changed return junk period ratio (in the case of no small integer period ratios) to be correctly ordered.

Additionally fixed testing file for feature classifier. One test independently sets up a Trio object and calls get_tseries, both meant to be internal functions. However, the starting features where never initiated resulting in un initiated values being used for calculations. 