### PR TITLE
Fix bug where Nout=1, leading to erroneous predictions

### DIFF
--- a/spock/featureclassifier.py
+++ b/spock/featureclassifier.py
@@ -153,9 +153,12 @@ class FeatureClassifier:
             Norbits = Nbodytmax # failsafe to avoid cases with very long short integration times
             warnings.warn(f'Min secular timescale > Nbodytmax orbits of inner most planet '\
                           f'Defaulting to integrating to {Nbodytmax} orbits. Might affect model performance')
+        
+        # Require at least 1000 orbits to calculate features
+        Norbits = max(Norbits, 1000)
+
         # set the number of outputs in short integration to be same as in original model (80 outputs over 1e4 orbits)
-        Nout = max(int((Norbits / 1e4) * 80), 3)
-        # Require at least 3 outputs to calcul^ate features
+        Nout = int((Norbits / 1e4) * 80)
 
         # make list of Trio objects for each adjacent trio
         trios = []

--- a/spock/featureclassifier.py
+++ b/spock/featureclassifier.py
@@ -154,7 +154,8 @@ class FeatureClassifier:
             warnings.warn(f'Min secular timescale > Nbodytmax orbits of inner most planet '\
                           f'Defaulting to integrating to {Nbodytmax} orbits. Might affect model performance')
         # set the number of outputs in short integration to be same as in original model (80 outputs over 1e4 orbits)
-        Nout = int((Norbits / 1e4) * 80)
+        Nout = max(int((Norbits / 1e4) * 80), 3)
+        # Require at least 3 outputs to calcul^ate features
 
         # make list of Trio objects for each adjacent trio
         trios = []


### PR DESCRIPTION
While applying `SPOCK` within an MCMC, I found that a large region of parameter space had the exact same stability probability of 0.8972374 . After some digging, it turned out that this was because `Nout=1` in this region, presumably due to a very short secular timescale. As a result, some features were erroneously calculated to be 0 or NaN, giving a mode collapse in the stability probability estimation.

This was amended by setting `Nout` to be at least 3, which allowed for more robust feature calculation and probability estimation.

The diff is highly simple and intuitive, and can be automatically merged.